### PR TITLE
Add Skiff Files volume mount

### DIFF
--- a/.skiff/webapp.jsonnet
+++ b/.skiff/webapp.jsonnet
@@ -199,6 +199,14 @@ function(
                     annotations: annotations
                 },
                 spec: {
+                    volumes: [
+                        { 
+                            name: 'skiff-files',
+                            persistentVolumeClaim: {
+                                claimName: 'skiff-files-server-paper-video-nav'
+                            }
+                        }
+                    ],
                     # This block tells the cluster that we'd like to make sure
                     # each instance of your application is on a different node. This
                     # way if a node goes down, your application doesn't:
@@ -226,6 +234,13 @@ function(
                         {
                             name: fullyQualifiedName + '-api',
                             image: apiImage,
+                            volumeMounts: [
+                                {
+                                    mountPath: '/skiff_files',
+                                    name: 'skiff-files',
+                                    readOnly: true
+                                }
+                            ],
                             # The "probes" below allow Kubernetes to determine
                             # if your application is working properly.
                             #


### PR DESCRIPTION
Addresses the request made in https://github.com/allenai/skiff/issues/1562.

I've created the persistent volume that connects to Skiff Files, and this change will mount it in the API container at the path `/skiff_files`. It looks like the build may be currently failing for other reasons, but this can be merged once it's working again.