### PR TITLE
bump evaluate to `0.3.0`

### DIFF
--- a/api/requirements.txt
+++ b/api/requirements.txt
@@ -14,7 +14,7 @@ datasets==2.4.0
 decorator==4.4.2
 dill==0.3.5.1
 effdet==0.3.0
-evaluate==0.2.2
+evaluate==0.3.0
 filelock==3.8.0
 Flask==2.2.2
 Flask-SQLAlchemy==3.0.0


### PR DESCRIPTION
There is an issue with `evaluate` before 0.3.0 concerning the Hugging Face hub integration. I suggest upgrading to `0.3.0` which should not have any breaking changes and be functionally equivalent since this version might break in a few months.